### PR TITLE
Add support for Forerunner® 165

### DIFF
--- a/HrvAlgorithms/manifest.xml
+++ b/HrvAlgorithms/manifest.xml
@@ -46,6 +46,7 @@
             <iq:product id="fenix8solar47mm"/>
             <iq:product id="fenixchronos"/>
             <iq:product id="fenixe"/>
+            <iq:product id="fr165"/>
             <iq:product id="fr165m"/>
             <iq:product id="fr245"/>
             <iq:product id="fr245m"/>

--- a/Meditate/manifest.xml
+++ b/Meditate/manifest.xml
@@ -40,6 +40,7 @@
             <iq:product id="fenix847mm"/>
             <iq:product id="fenix8solar47mm"/>
             <iq:product id="fenixe"/>
+            <iq:product id="fr165"/>
             <iq:product id="fr165m"/>
             <iq:product id="fr245m"/>
             <iq:product id="fr255"/>

--- a/ScreenPicker/manifest.xml
+++ b/ScreenPicker/manifest.xml
@@ -47,6 +47,7 @@
             <iq:product id="fenix8solar47mm"/>
             <iq:product id="fenixchronos"/>
             <iq:product id="fenixe"/>
+            <iq:product id="fr165"/>
             <iq:product id="fr165m"/>
             <iq:product id="fr245"/>
             <iq:product id="fr245m"/>

--- a/StatusIconFonts/manifest.xml
+++ b/StatusIconFonts/manifest.xml
@@ -47,6 +47,7 @@
             <iq:product id="fenix8solar47mm"/>
             <iq:product id="fenixchronos"/>
             <iq:product id="fenixe"/>
+            <iq:product id="fr165"/>
             <iq:product id="fr165m"/>
             <iq:product id="fr245"/>
             <iq:product id="fr245m"/>


### PR DESCRIPTION
Thank you for your work. 🙏

I wanted to run this app on my Forerunner 165, but couldn't install through Garmin IQ. Noticed that the model is not listed in the xml files.

- confirmed that the app is running in my own watch.
  - built for Forerunner 165.
  - copied `prg` file to GARMIN/Apps.