### PR TITLE
Hrv

### DIFF
--- a/HrvAlgorithms/sources/activity/ActivitySummary.mc
+++ b/HrvAlgorithms/sources/activity/ActivitySummary.mc
@@ -2,6 +2,5 @@ module HrvAlgorithms {
 	class ActivitySummary {
 		var hrSummary;
 		var hrvSummary;
-		var stress;
 	}
 }

--- a/HrvAlgorithms/sources/activity/RrActivity.mc
+++ b/HrvAlgorithms/sources/activity/RrActivity.mc
@@ -32,7 +32,7 @@ module HrvAlgorithms {
 		private var firstBadMesure = true;
 
 		// Method to be used without class instance
-		function isRespirationRateSupported(){
+		static function isRespirationRateSupported(){
 			if (ActivityMonitor.getInfo() has :respirationRate) {
 				return true;
 			} else {

--- a/HrvAlgorithms/sources/activity/hrv/HrvMonitorDetailed.mc
+++ b/HrvAlgorithms/sources/activity/hrv/HrvMonitorDetailed.mc
@@ -141,7 +141,11 @@ module HrvAlgorithms {
 			
 			me.mHrvPnn50.addBeatToBeatInterval(beatToBeatInterval);
 			me.mHrvPnn20.addBeatToBeatInterval(beatToBeatInterval);				
-		}			
+		}
+
+		public function getRmssdRolling() {
+			return mHrvRmssd30Sec.getLastCalcValue();
+		}
 					
 		public function calculateHrvSummary() {		
 			var hrvSummary = HrvMonitorDefault.calculateHrvSummary();	
@@ -162,6 +166,7 @@ module HrvAlgorithms {
 			if (hrvSummary.last5MinSdrr != null) {
 				me.mHrvSdrrLast5MinDataField.setData(hrvSummary.last5MinSdrr);
 			}
+			hrvSummary.rmssdHistory = me.mHrvRmssd30Sec.getHistory();
 			return hrvSummary;
 		}
 	}	

--- a/HrvAlgorithms/sources/activity/hrv/HrvMonitorDetailed.mc
+++ b/HrvAlgorithms/sources/activity/hrv/HrvMonitorDetailed.mc
@@ -122,7 +122,7 @@ module HrvAlgorithms {
 		function addOneSecBeatToBeatIntervals(beatToBeatIntervals) {
 			HrvMonitorDefault.addOneSecBeatToBeatIntervals(beatToBeatIntervals);
 
-	    	var rmssd30Sec = me.mHrvRmssd30Sec.addOneSecBeatToBeatIntervals(beatToBeatIntervals); 	
+	    	var rmssd30Sec = me.mHrvRmssd30Sec.addOneSec(beatToBeatIntervals); 	
 	    	if (rmssd30Sec != null) {
 	    		me.mHrvRmssd30SecDataField.setData(rmssd30Sec);
 	    	}	
@@ -136,8 +136,8 @@ module HrvAlgorithms {
 			var hrFromHeartbeat = Math.round(60000 / beatToBeatInterval.toFloat()).toNumber();
 			me.mHrFromHeartbeatDataField.setData(hrFromHeartbeat);
 			
-			me.mHrvSdrrFirst5Min.addBeatToBeatInterval(beatToBeatInterval);
-			me.mHrvSdrrLast5Min.addBeatToBeatInterval(beatToBeatInterval);
+			me.mHrvSdrrFirst5Min.addData(beatToBeatInterval);
+			me.mHrvSdrrLast5Min.addData(beatToBeatInterval);
 			
 			me.mHrvPnn50.addBeatToBeatInterval(beatToBeatInterval);
 			me.mHrvPnn20.addBeatToBeatInterval(beatToBeatInterval);				

--- a/HrvAlgorithms/sources/activity/hrv/HrvRmssd.mc
+++ b/HrvAlgorithms/sources/activity/hrv/HrvRmssd.mc
@@ -13,7 +13,6 @@ module HrvAlgorithms {
 		function addBeatToBeatInterval(beatToBeatInterval) {
 			if (me.mPreviousBeatToBeatInterval != null) {
 				me.mBeatToBeatIntervalsCount++;					
-				
 				me.mSquareOfSuccessiveBtbDifferences += Math.pow(beatToBeatInterval - me.mPreviousBeatToBeatInterval, 2);	
 			}		
 			me.mPreviousBeatToBeatInterval = beatToBeatInterval;
@@ -23,7 +22,6 @@ module HrvAlgorithms {
 			if (me.mBeatToBeatIntervalsCount < 1) {
 				return null;
 			}
-			
 			var rootMeanSquareOfSuccessiveBtbDifferences = Math.sqrt(me.mSquareOfSuccessiveBtbDifferences / me.mBeatToBeatIntervalsCount);		
 			return rootMeanSquareOfSuccessiveBtbDifferences;
 		}

--- a/HrvAlgorithms/sources/activity/hrv/HrvRmssdRolling.mc
+++ b/HrvAlgorithms/sources/activity/hrv/HrvRmssdRolling.mc
@@ -7,12 +7,13 @@ module HrvAlgorithms {
 			me.aggregatedValue += Math.pow(value - me.previousValue, 2);
 		}
 		
-		private function calculate() {
+		function calculate() {
 			if (me.secondsCount < me.rollingIntervalSeconds || me.count < 1) {
 				return null;
 			}
-			var result = Math.sqrt(me.aggregatedValue / me.count.toFloat());	
+			var result = Math.sqrt(me.aggregatedValue / me.count.toFloat());
 			me.reset();
+			me.data.add(result);
 			return result;
 		}
 	}

--- a/HrvAlgorithms/sources/activity/hrv/HrvRmssdRolling.mc
+++ b/HrvAlgorithms/sources/activity/hrv/HrvRmssdRolling.mc
@@ -1,48 +1,19 @@
 module HrvAlgorithms {
-	class HrvRmssdRolling {
-		function initialize(rollingIntervalSeconds) {	
-			me.mRollingIntervalSeconds = rollingIntervalSeconds;		
-			me.reset();
+	class HrvRmssdRolling extends Rolling {
+		function initialize(rollingIntervalSeconds) {
+			Rolling.initialize(rollingIntervalSeconds);
 		}
-			
-		private var mRollingIntervalSeconds;
-		private var mSecondsCount;	
-		private var mSquareOfSuccessiveBtbDifferences;	
-		private var mPreviousBeatToBeatInterval;
-		private var mBeatToBeatIntervalsCount;
-		
-		private function reset() {
-			me.mSecondsCount = 0;	
-			me.mSquareOfSuccessiveBtbDifferences = 0.0;
-			me.mBeatToBeatIntervalsCount = 0;
-			me.mPreviousBeatToBeatInterval = null;
-		}
-		
-		function addOneSecBeatToBeatIntervals(beatToBeatIntervals) {
-			for (var i = 0; i < beatToBeatIntervals.size(); i++) {
-				me.addBeatToBeatInterval(beatToBeatIntervals[i]);
-			}
-			me.mSecondsCount++;
-			return me.calculate();
-		}
-		
-		private function addBeatToBeatInterval(beatToBeatInterval) {
-			if (me.mPreviousBeatToBeatInterval != null) {
-				me.mBeatToBeatIntervalsCount++;					
-				
-				me.mSquareOfSuccessiveBtbDifferences += Math.pow(beatToBeatInterval - me.mPreviousBeatToBeatInterval, 2);	
-			}		
-			me.mPreviousBeatToBeatInterval = beatToBeatInterval;
+		function aggregate(value) {
+			me.aggregatedValue += Math.pow(value - me.previousValue, 2);
 		}
 		
 		private function calculate() {
-			if (me.mSecondsCount < me.mRollingIntervalSeconds || me.mBeatToBeatIntervalsCount < 1) {
+			if (me.secondsCount < me.rollingIntervalSeconds || me.count < 1) {
 				return null;
 			}
-			
-			var rootMeanSquareOfSuccessiveBtbDifferences = Math.sqrt(me.mSquareOfSuccessiveBtbDifferences / me.mBeatToBeatIntervalsCount);	
-			me.reset();	
-			return rootMeanSquareOfSuccessiveBtbDifferences;
+			var result = Math.sqrt(me.aggregatedValue / me.count.toFloat());	
+			me.reset();
+			return result;
 		}
 	}
 }

--- a/HrvAlgorithms/sources/activity/hrv/HrvSdrrFirstNSec.mc
+++ b/HrvAlgorithms/sources/activity/hrv/HrvSdrrFirstNSec.mc
@@ -1,43 +1,18 @@
 module HrvAlgorithms {
-	class HrvSdrrFirstNSec {
+	class HrvSdrrFirstNSec extends WindowAvg{
 		function initialize(maxIntervalsCount) {
-			me.mMaxIntervalsCount = maxIntervalsCount;
-			me.mBeatToBeatIntervalsCount = 0;
-			me.mIntervals = new [maxIntervalsCount];
-		}
-		
-		private var mMaxIntervalsCount;
-		private var mBeatToBeatIntervalsCount;
-		private var mIntervals;
-		
-		function addBeatToBeatInterval(beatToBeatInterval) {
-			if (me.mBeatToBeatIntervalsCount >= me.mMaxIntervalsCount) {
-				return;
-			}
-			
-			if (beatToBeatInterval != null) {
-				me.mBeatToBeatIntervalsCount++;		
-				
-				var intervalsIndex = me.mBeatToBeatIntervalsCount - 1;
-				me.mIntervals[intervalsIndex] = beatToBeatInterval.toFloat();
-			}		
-		}
-		
+			WindowAvg.initialize(maxIntervalsCount, true);
+		}		
 		function calculate() {
-			if (me.mBeatToBeatIntervalsCount < 2) {
+			var avg = WindowAvg.calculate();
+			if (avg == null) {
 				return null;
 			}
-			
-			var sumBeatToBeat = 0.0;
-			for (var i = 0; i < me.mBeatToBeatIntervalsCount; i++) {
-				sumBeatToBeat += me.mIntervals[i];
-			}
-			var meanBeatToBeat = sumBeatToBeat / me.mBeatToBeatIntervalsCount.toFloat();		
 			var sumSquaredDeviations = 0.0;
-			for (var i = 0; i < me.mBeatToBeatIntervalsCount; i++) {
-				sumSquaredDeviations += Math.pow(me.mIntervals[i] - meanBeatToBeat, 2);	
+			for (var i = 0; i < me.count; i++) {
+				sumSquaredDeviations += Math.pow(me.data[i] - avg, 2);	
 			}
-			return Math.sqrt(sumSquaredDeviations / me.mBeatToBeatIntervalsCount.toFloat());
+			return Math.sqrt(sumSquaredDeviations / me.count.toFloat());
 		}
 	}
 }

--- a/HrvAlgorithms/sources/activity/hrv/HrvSdrrLastNSec.mc
+++ b/HrvAlgorithms/sources/activity/hrv/HrvSdrrLastNSec.mc
@@ -1,48 +1,18 @@
 module HrvAlgorithms {
-	class HrvSdrrLastNSec {
-		function initialize(intervalsCount) {
-			me.mIntervalsCount = intervalsCount;
-			me.mBeatToBeatIntervalsCount = 0;
-			me.mIntervals = new [intervalsCount];
-			me.mBufferCurrentIndex = 0;
-		}
-		
-		private var mIntervalsCount;
-		private var mBeatToBeatIntervalsCount;
-		private var mIntervals;
-		
-		private var mBufferCurrentIndex;
-		
-		function addBeatToBeatInterval(beatToBeatInterval) {		
-			if (beatToBeatInterval != null) {
-				me.mBeatToBeatIntervalsCount++;		
-				
-				me.storeBeatToBeatInterval(beatToBeatInterval);
-			}		
-		}
-		
-		private function storeBeatToBeatInterval(beatToBeatInterval) {
-			me.mIntervals[me.mBufferCurrentIndex] = beatToBeatInterval.toFloat();
-			var bufferIndexRewinded = (me.mBufferCurrentIndex + 1) % me.mIntervalsCount;
-			me.mBufferCurrentIndex = bufferIndexRewinded;
-		}
-			
+	class HrvSdrrLastNSec extends WindowAvg{
+		function initialize(maxIntervalsCount) {
+			WindowAvg.initialize(maxIntervalsCount, false);
+		}		
 		function calculate() {
-			if (me.mBeatToBeatIntervalsCount < me.mIntervalsCount) {
+			var avg = WindowAvg.calculate();
+			if (avg == null) {
 				return null;
 			}
-			
-			var sumBeatToBeat = 0.0;
-			for (var i = 0; i < me.mIntervalsCount; i++) {
-				sumBeatToBeat += me.mIntervals[i];
-			}
-			var meanBeatToBeat = sumBeatToBeat / me.mIntervalsCount.toFloat();
-			
 			var sumSquaredDeviations = 0.0;
-			for (var i = 0; i < me.mIntervalsCount; i++) {			
-				sumSquaredDeviations += Math.pow(me.mIntervals[i] - meanBeatToBeat, 2);
+			for (var i = 0; i < me.count; i++) {
+				sumSquaredDeviations += Math.pow(me.data[i] - avg, 2);	
 			}
-			return Math.sqrt(sumSquaredDeviations / me.mIntervalsCount.toFloat());
+			return Math.sqrt(sumSquaredDeviations / me.count.toFloat());
 		}
 	}
 }

--- a/HrvAlgorithms/sources/activity/hrv/HrvSummary.mc
+++ b/HrvAlgorithms/sources/activity/hrv/HrvSummary.mc
@@ -5,5 +5,6 @@ module HrvAlgorithms {
 		var pnn20;
 		var first5MinSdrr;
 		var last5MinSdrr;
+		var rmssdHistory;
 	}
 }

--- a/HrvAlgorithms/sources/activity/hrv/Rolling.mc
+++ b/HrvAlgorithms/sources/activity/hrv/Rolling.mc
@@ -1,0 +1,51 @@
+module HrvAlgorithms {
+	class Rolling {
+		function initialize(rollingIntervalSeconds) {	
+			me.rollingIntervalSeconds = rollingIntervalSeconds;		
+			me.reset();
+		}
+			
+		var rollingIntervalSeconds;
+		var secondsCount;	
+		var previousValue;
+		var count;
+		var aggregatedValue;
+		
+		function reset() {
+			me.secondsCount = 0;	
+			me.count = 0;
+			me.previousValue = null;
+			me.aggregatedValue = 0.0;
+		}
+		
+		function addOneSec(data) {
+			for (var i = 0; i < data.size(); i++) {
+				me.addValue(data[i]);
+			}
+			me.secondsCount++;
+			return me.calculate();
+		}
+		
+		function addValue(value) {
+			if (me.previousValue != null) {
+				me.count++;
+				me.aggregate(value);
+			}
+			me.previousValue = value;
+		}
+
+		function aggregate(value) {
+			me.aggregatedValue += value;
+		}
+	
+		function calculate() {
+			if (me.secondsCount < me.rollingIntervalSeconds || me.count < 1) {
+				return null;
+			}
+			
+			var result = me.aggregatedValue / me.count.toFloat();
+			me.reset();
+			return result;
+		}
+	}
+}

--- a/HrvAlgorithms/sources/activity/hrv/WindowAvg.mc
+++ b/HrvAlgorithms/sources/activity/hrv/WindowAvg.mc
@@ -1,0 +1,37 @@
+module HrvAlgorithms {
+	class WindowAvg {
+		function initialize(windowSize, first) {
+			me.windowSize = windowSize;
+			me.count = 0;
+			me.data = new [me.windowSize];
+			me.first = first;
+		}
+		
+		var windowSize;
+		var count;
+		var data;
+		var first;
+		
+		function addData(data) {
+			if (me.count >= me.windowSize && me.first) {
+				return;
+			}
+			
+			if (data != null) {
+				me.data[me.count % me.windowSize] = data.toNumber();
+				me.count++;
+			}
+		}
+		
+		function calculate() {
+			if (me.count < 2) {
+				return null;
+			}			
+			var sum = 0;
+			for (var i = 0; i < me.count; i++) {
+				sum += me.data[i];
+			}
+			return sum / me.count.toFloat();
+		}
+	}
+}

--- a/HrvAlgorithms/sources/activity/stress/HrPeaksWindow.mc
+++ b/HrvAlgorithms/sources/activity/stress/HrPeaksWindow.mc
@@ -57,21 +57,21 @@ module HrvAlgorithms {
 			if (me.mStoredSamplesCount < me.mSamples.size()) {
 				return null;
 			}
-			var maxHr = null;
+			var maxHr = -1;
 			for (var i = 0; i < me.mSamples.size(); i++) {
 				if (me.mSamples[i].size() > 0) {
 					for (var s = 0; s < me.mSamples[i].size(); s++) { 
 						var beatToBeatSample = me.mSamples[i][s];
 						var bpmSample =  Math.round(60000 / beatToBeatSample.toFloat()).toNumber();
 						
-						if (maxHr == null || bpmSample > maxHr) {
+						if (maxHr == -1 || bpmSample > maxHr) {
 							maxHr = bpmSample;
 						}
 					}
 				}
 			}
 			
-			if (maxHr == null) {
+			if (maxHr == -1) {
 				return null;
 			}
 			return maxHr;

--- a/HrvAlgorithms/sources/activity/stress/StressMonitor.mc
+++ b/HrvAlgorithms/sources/activity/stress/StressMonitor.mc
@@ -7,7 +7,7 @@ module HrvAlgorithms {
 			me.mHrvTracking = hrvTracking;
 			if (me.mHrvTracking == HrvTracking.OnDetailed) {		
 				me.mHrPeaksWindow10DataField = StressMonitor.createHrPeaksWindow10DataField(activitySession);			
-			}
+			} 
 			if (me.mHrvTracking != HrvTracking.Off) {		
 				me.mHrPeaksAverageDataField = StressMonitor.createHrPeaksAverageDataField(activitySession);			
 				me.mHrPeaksWindow10 = new HrPeaksWindow(10);	
@@ -16,7 +16,7 @@ module HrvAlgorithms {
 								
 		private var mHrvTracking;
 		
-		private var mHrPeaksWindow10;	
+		private var mHrPeaksWindow10;
 		
 		private var mHrPeaksWindow10DataField;
 		private var mHrPeaksAverageDataField;

--- a/HrvAlgorithms/sources/activity/utils/Rolling.mc
+++ b/HrvAlgorithms/sources/activity/utils/Rolling.mc
@@ -3,6 +3,8 @@ module HrvAlgorithms {
 		function initialize(rollingIntervalSeconds) {	
 			me.rollingIntervalSeconds = rollingIntervalSeconds;		
 			me.reset();
+			me.data = [];
+			me.previousValue = null;
 		}
 			
 		var rollingIntervalSeconds;
@@ -10,11 +12,11 @@ module HrvAlgorithms {
 		var previousValue;
 		var count;
 		var aggregatedValue;
+		var data;
 		
 		function reset() {
 			me.secondsCount = 0;	
 			me.count = 0;
-			me.previousValue = null;
 			me.aggregatedValue = 0.0;
 		}
 		
@@ -27,15 +29,26 @@ module HrvAlgorithms {
 		}
 		
 		function addValue(value) {
-			if (me.previousValue != null) {
+			if (me.previousValue != null && value != null) {
 				me.count++;
 				me.aggregate(value);
 			}
-			me.previousValue = value;
+			if ( value != null) {
+				me.previousValue = value;
+			}
 		}
 
 		function aggregate(value) {
 			me.aggregatedValue += value;
+		}
+
+		function getLastCalcValue() {
+			if (me.data.size() > 0)
+			{
+				return me.data[me.data.size()-1];
+			} else {
+				return null;
+			}
 		}
 	
 		function calculate() {
@@ -45,7 +58,12 @@ module HrvAlgorithms {
 			
 			var result = me.aggregatedValue / me.count.toFloat();
 			me.reset();
+			me.data.add(result);
 			return result;
+		}
+
+		function getHistory() {
+			return me.data;
 		}
 	}
 }

--- a/HrvAlgorithms/sources/activity/utils/WindowAvg.mc
+++ b/HrvAlgorithms/sources/activity/utils/WindowAvg.mc
@@ -13,12 +13,13 @@ module HrvAlgorithms {
 		var first;
 		
 		function addData(data) {
-			if (me.count >= me.windowSize && me.first) {
+			if (me.first && me.count >= me.windowSize) {
 				return;
 			}
 			
 			if (data != null) {
-				me.data[me.count % me.windowSize] = data.toNumber();
+				me.count = me.count % me.windowSize;
+				me.data[me.count] = data.toNumber();
 				me.count++;
 			}
 		}
@@ -28,8 +29,12 @@ module HrvAlgorithms {
 				return null;
 			}			
 			var sum = 0;
+			var val = 0;
 			for (var i = 0; i < me.count; i++) {
-				sum += me.data[i];
+				val = me.data[i];
+				if (val != null){
+					sum += me.data[i];
+				}
 			}
 			return sum / me.count.toFloat();
 		}

--- a/Meditate/source/YesDelegate.mc
+++ b/Meditate/source/YesDelegate.mc
@@ -10,7 +10,9 @@ class YesDelegate extends Ui.ConfirmationDelegate {
 
     function onResponse(value) {
         if (value == Ui.CONFIRM_YES) {  
-        	me.mOnYes.invoke();      	    
-        }        
+        	me.mOnYes.invoke();
+            return true;
+        }
+        return false;
     }
 }

--- a/Meditate/source/YesNoDelegate.mc
+++ b/Meditate/source/YesNoDelegate.mc
@@ -11,7 +11,9 @@ class YesNoDelegate extends YesDelegate {
     function onResponse(value) {
     	YesDelegate.onResponse(value);
     	if (value == Ui.CONFIRM_NO) {     		
-        	me.mOnNo.invoke();   
+        	me.mOnNo.invoke();
+			return false;
     	}
+		return true;
     }    
 }

--- a/Meditate/source/activity/DelayedFinishingView.mc
+++ b/Meditate/source/activity/DelayedFinishingView.mc
@@ -17,7 +17,6 @@ class DelayedFinishingView extends Ui.View {
 		// Exit app if required
 		if (me.mShouldAutoExit) {
 			System.exit();
-			return;
 		}
 
 		me.mOnShow.invoke();

--- a/Meditate/source/activity/MeditateActivity.mc
+++ b/Meditate/source/activity/MeditateActivity.mc
@@ -100,14 +100,14 @@ class MediteActivity extends HrvAlgorithms.HrvAndStressActivity {
 		me.mVibeAlertsExecutor = new VibeAlertsExecutor(me.mMeditateModel);	
 	}	
 				
-	protected function onRefreshHrvActivityStats(activityInfo, minHr, hrvSuccessive) {	
+	protected function onRefreshHrvActivityStats(activityInfo, minHr, hrvValue) {	
 		if (activityInfo.elapsedTime != null) {
 			me.mMeditateModel.elapsedTime = activityInfo.timerTime / 1000;
 		}
 		me.mMeditateModel.currentHr = activityInfo.currentHeartRate;
 		me.mMeditateModel.minHr = minHr;
 		me.mVibeAlertsExecutor.firePendingAlerts();	 
-		me.mMeditateModel.hrvSuccessive = hrvSuccessive;
+		me.mMeditateModel.hrvValue = hrvValue;
     	
 		// Check if we need to stop activity automatically when time ended
 		var autoStopEnabled = GlobalSettings.loadAutoStop();

--- a/Meditate/source/activity/MeditateActivity.mc
+++ b/Meditate/source/activity/MeditateActivity.mc
@@ -20,12 +20,10 @@ class MediteActivity extends HrvAlgorithms.HrvAndStressActivity {
 
 		if (meditateModel.getActivityType() == ActivityType.Yoga) {
 			fitSessionSpec = HrvAlgorithms.FitSessionSpec.createYoga(createSessionName(sessionTime, activityNameProperty)); // Due to bug in Connect IQ API for breath activity to get respiration rate, we will use Yoga as default meditate activity
-		}
-		if (meditateModel.getActivityType() == ActivityType.Meditating) {
-			fitSessionSpec = HrvAlgorithms.FitSessionSpec.createMeditation(createSessionName(sessionTime, activityNameProperty));
-		}
-		if (meditateModel.getActivityType() == ActivityType.Breathing) {
+		} else if (meditateModel.getActivityType() == ActivityType.Breathing) {
 			fitSessionSpec = HrvAlgorithms.FitSessionSpec.createBreathing(createSessionName(sessionTime, activityNameProperty));
+		} else {
+			fitSessionSpec = HrvAlgorithms.FitSessionSpec.createMeditation(createSessionName(sessionTime, activityNameProperty));
 		}
 
 		me.mMeditateModel = meditateModel;	

--- a/Meditate/source/activity/MeditateDelegate.mc
+++ b/Meditate/source/activity/MeditateDelegate.mc
@@ -141,5 +141,6 @@ class MeditateDelegate extends Ui.BehaviorDelegate {
 				Attention.backlight(backlightOn);
 			}
 		}
+		return true;
 	}
 }

--- a/Meditate/source/activity/MeditateModel.mc
+++ b/Meditate/source/activity/MeditateModel.mc
@@ -74,7 +74,7 @@ class MeditateModel {
 		return isRespirationRateOnStatic(me.rrActivity);
 	}
 
-	function isRespirationRateOnStatic(rrActivity) {
+	static function isRespirationRateOnStatic(rrActivity) {
 
 		// Check if watch supports respiration rate
 		if (rrActivity.isSupported()) {

--- a/Meditate/source/activity/MeditateModel.mc
+++ b/Meditate/source/activity/MeditateModel.mc
@@ -7,7 +7,7 @@ class MeditateModel {
 		me.elapsedTime = 0;
 		me.minHr = null;
 		me.currentHr = null;
-		me.hrvSuccessive = null;
+		me.hrvValue = null;
 		me.respirationRate = null;
 		me.isTimerRunning = false;
 		me.rrActivity = new HrvAlgorithms.RrActivity();
@@ -19,7 +19,7 @@ class MeditateModel {
 	var currentHr;
 	var minHr;
 	var elapsedTime;
-	var hrvSuccessive;
+	var hrvValue;
 	var respirationRate;
 	var isTimerRunning;
 

--- a/Meditate/source/activity/MeditateView.mc
+++ b/Meditate/source/activity/MeditateView.mc
@@ -17,6 +17,7 @@ class MeditateView extends Ui.View {
         me.mElapsedTime = null; 
         me.mHrStatusText = null;
         me.mMeditateIcon = null;
+		me.timeXPos = null;
 
 		// If we have respiration rate and HRV on , we should push all text and icons one line below
 		if (mMeditateModel.isRespirationRateOn() && me.mMeditateModel.isHrvOn()) {
@@ -113,8 +114,8 @@ class MeditateView extends Ui.View {
     	return dc.getHeight() / 2 + lineOffset * dc.getFontHeight(TextFont);
     }
 	
-    function renderLayoutElapsedTime(dc) { 	
-    	var xPosCenter = dc.getWidth() / 2;
+    function renderLayoutElapsedTime(dc) { 
+		var xPosCenter = dc.getWidth() / 2; 
     	var yPosCenter = getYPosOffsetFromCenter(dc, -1 + mRespirationRateYPosOffset);
     	me.mElapsedTime = createMeditateText(me.mMeditateModel.getColor(), TextFont, xPosCenter, yPosCenter, Gfx.TEXT_JUSTIFY_CENTER);
     }
@@ -187,7 +188,9 @@ class MeditateView extends Ui.View {
         	mMeditateIcon.draw(dc);
         }
 		
-		var timeText = TimeFormatter.format(me.mMeditateModel.elapsedTime);
+		var elapsedTime = me.mMeditateModel.elapsedTime;
+		var timeText = TimeFormatter.format(elapsedTime);
+		
 		timeText = timeText.substring(0, timeText.length()-3);
 		
 		var currentHr = me.mMeditateModel.currentHr;
@@ -205,7 +208,6 @@ class MeditateView extends Ui.View {
 		me.mElapsedTime.draw(dc);
                     
         var alarmTime = me.mMeditateModel.getSessionTime();
-		var elapsedTime = me.mMeditateModel.elapsedTime;
 
 		// Fix issues with OLED screens for prepare time 45 seconds
 		if (elapsedTime <= 1)

--- a/Meditate/source/activity/MeditateView.mc
+++ b/Meditate/source/activity/MeditateView.mc
@@ -188,15 +188,17 @@ class MeditateView extends Ui.View {
         }
 		
 		var timeText = TimeFormatter.format(me.mMeditateModel.elapsedTime);
+		timeText = timeText.substring(0, timeText.length()-3);
+		
 		var currentHr = me.mMeditateModel.currentHr;
-		var hrvSuccessive = me.mMeditateModel.hrvSuccessive;
+		var hrvValue = me.mMeditateModel.hrvValue;
 
 		// Check if activity is paused, render the [Paused] text
 		// and hide HR/HRV metrics
 		if (!me.mMeditateModel.isTimerRunning)  {
 			timeText = Ui.loadResource(Rez.Strings.meditateActivityPaused);
 			currentHr = null;
-			hrvSuccessive = null;
+			hrvValue = null;
 		}
 
 		me.mElapsedTime.setText(timeText);		
@@ -232,7 +234,7 @@ class MeditateView extends Ui.View {
      	
  	    if (me.mMeditateModel.isHrvOn() == true) {
 	        me.mHrvIcon.draw(dc);
-	        me.mHrvText.setText(me.formatHrv(hrvSuccessive));
+	        me.mHrvText.setText(me.formatHrv(hrvValue));
 	        me.mHrvText.draw(dc);
         }
 

--- a/Meditate/source/activity/MeditateView.mc
+++ b/Meditate/source/activity/MeditateView.mc
@@ -233,7 +233,7 @@ class MeditateView extends Ui.View {
  	    if (me.mMeditateModel.isHrvOn() == true) {
 	        me.mHrvIcon.draw(dc);
 	        me.mHrvText.setText(me.formatHrv(hrvSuccessive));
-	        me.mHrvText.draw(dc); 
+	        me.mHrvText.draw(dc);
         }
 
 		// Only get respiration rate every second

--- a/Meditate/source/activity/MeditateView.mc
+++ b/Meditate/source/activity/MeditateView.mc
@@ -17,7 +17,6 @@ class MeditateView extends Ui.View {
         me.mElapsedTime = null; 
         me.mHrStatusText = null;
         me.mMeditateIcon = null;
-		me.timeXPos = null;
 
 		// If we have respiration rate and HRV on , we should push all text and icons one line below
 		if (mMeditateModel.isRespirationRateOn() && me.mMeditateModel.isHrvOn()) {

--- a/Meditate/source/activity/Vibe.mc
+++ b/Meditate/source/activity/Vibe.mc
@@ -14,7 +14,7 @@ class Vibe {
 			return;
 		}
 
-		var vibeProfile;
+		var vibeProfile = getLongContinuous();
 		switch (pattern) {
 			case VibePattern.LongContinuous:
 				vibeProfile = getLongContinuous();

--- a/Meditate/source/sessionSettings/SessionPickerDelegate.mc
+++ b/Meditate/source/sessionSettings/SessionPickerDelegate.mc
@@ -73,16 +73,15 @@ class SessionPickerDelegate extends ScreenPicker.ScreenPickerDelegate {
     
     private const RollupExitOption = :exitApp;
     
-    function onBack() {         	
-    	if (me.mSummaryRollupModel.getSummaries().size() > 0) {
-    		var summaries = me.mSummaryRollupModel.getSummaries();
-    		
+    function onBack() {
+		var summaries = me.mSummaryRollupModel.getSummaries(); 	
+    	if (summaries.size() > 0) {   		
     		var summaryRollupMenu = new Ui.Menu();
 			summaryRollupMenu.setTitle(Ui.loadResource(Rez.Strings.summaryRollupMenu_title));
 			summaryRollupMenu.addItem(Ui.loadResource(Rez.Strings.summaryRollupMenuOption_exit), RollupExitOption);
 			for (var i = 0; i < summaries.size(); i++) {
     			summaryRollupMenu.addItem(TimeFormatter.format(summaries[i].elapsedTime), i);
-    		}			
+    		}
 			var summaryRollupMenuDelegate = new MenuOptionsDelegate(method(:onSummaryRollupMenuOption));
 			Ui.pushView(summaryRollupMenu, summaryRollupMenuDelegate, Ui.SLIDE_LEFT);	
 			return true;
@@ -161,8 +160,6 @@ class SessionPickerDelegate extends ScreenPicker.ScreenPickerDelegate {
 		
 	private static function getVibePatternText(vibePattern) {
 		switch (vibePattern) {
-			case VibePattern.NoNotification:
-				return Ui.loadResource(Rez.Strings.vibePatternMenu_noNotification);
 			case VibePattern.LongPulsating:
 				return Ui.loadResource(Rez.Strings.vibePatternMenu_longPulsating);
 			case VibePattern.LongSound:
@@ -183,6 +180,8 @@ class SessionPickerDelegate extends ScreenPicker.ScreenPickerDelegate {
 				return Ui.loadResource(Rez.Strings.vibePatternMenu_shortContinuous);
 			case VibePattern.ShortPulsating:
 				return Ui.loadResource(Rez.Strings.vibePatternMenu_shortPulsating);
+			default:
+				return Ui.loadResource(Rez.Strings.vibePatternMenu_noNotification);
 		}
 	}
 	

--- a/Meditate/source/sessionSettings/durationPicker/DurationPickerDelegate.mc
+++ b/Meditate/source/sessionSettings/durationPicker/DurationPickerDelegate.mc
@@ -19,6 +19,7 @@ class DurationPickerDelegate extends Ui.BehaviorDelegate {
 			me.mModel.startPickingDigits();
 			Ui.requestUpdate();
 		}
+		return true;
 	}
 	
 	function finishPickingDigits() {

--- a/Meditate/source/storage/SessionStorage.mc
+++ b/Meditate/source/storage/SessionStorage.mc
@@ -64,7 +64,7 @@ class SessionStorage {
 			
 	function addSession(initialization) {
 		var finalIndex = 0;
-		var firstSession;
+		var firstSession = null;
 
 		// If initializing data first time, add the 6 initial mediation sessions
 		if (initialization) {

--- a/Meditate/source/summaryScreen/GraphView.mc
+++ b/Meditate/source/summaryScreen/GraphView.mc
@@ -91,21 +91,21 @@ class GraphView extends ScreenPicker.ScreenPickerView  {
 		dc.drawText(centerX - centerX / 2 + 10, 
 					centerY - centerY / 2 + 10, 
 					Gfx.FONT_SYSTEM_TINY, 
-					Ui.loadResource(Rez.Strings.SummaryMin) + me.min.toString(), 
+					Ui.loadResource(Rez.Strings.SummaryMin) + Math.round(me.min).toString(), 
 					Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 
 		// Draw AVG HR text
 		dc.drawText(centerX, 
 					centerY + centerY / 2 + 3, 
 					Gfx.FONT_SYSTEM_TINY, 
-					Ui.loadResource(Rez.Strings.SummaryAvg) + me.avg.toString(), 
+					Ui.loadResource(Rez.Strings.SummaryAvg) + Math.round(me.avg).toString(), 
 					Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 
 		// Draw MAX HR text
 		dc.drawText(centerX + centerX / 2 - 10, 
 					centerY - centerY / 2 + 10, 
 					Gfx.FONT_SYSTEM_TINY, 
-					Ui.loadResource(Rez.Strings.SummaryMax) + me.max.toString(), 
+					Ui.loadResource(Rez.Strings.SummaryMax) + Math.round(me.max).toString(), 
 					Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 
 		// Draw Time text

--- a/Meditate/source/summaryScreen/GraphView.mc
+++ b/Meditate/source/summaryScreen/GraphView.mc
@@ -131,13 +131,19 @@ class GraphView extends ScreenPicker.ScreenPickerView  {
 		var yMin = null;
 		var yMax = null;
 		if (me.data.size() > 1 && me.min != null && me.max != null) {
-			// Reduce a bit the min heart rate so it will show in the chart
-			yMin = Math.floor(me.min * 0.99);
-			yMax = Math.ceil(me.max * 1.01);
+			// Calculate different between min and max
+			minMaxDiff = (me.max - me.min).toFloat();
+			if (minMaxDiff == 0) {
+				minMaxDiff = 1;
+			}
 
-			// Calculate different between min and max HR
+			// Reduce a bit the min heart rate so it will show in the chart
+			var yOffset = Math.ceil(minMaxDiff * 0.1);
+			yMin = Math.floor(me.min.toFloat() - yOffset);
+			yMax = Math.ceil(me.max.toFloat() + yOffset);
+			// update min max diff
 			minMaxDiff = (yMax - yMin).toFloat();
-			
+
 			// Chart as light blue
 			dc.setPenWidth(1);
 			dc.setColor(0x27a0c4, Graphics.COLOR_TRANSPARENT);
@@ -171,7 +177,7 @@ class GraphView extends ScreenPicker.ScreenPickerView  {
 				for (var j = 0; j < expandFact; j++){		
 					var lineHeight = 0;
 					if (val!=null) {
-						lineHeight = (val-yMin) * (graph_height.toFloat() / minMaxDiff.toFloat());
+						lineHeight = (val-yMin) * (graph_height.toFloat() / minMaxDiff);
 					}
 					dc.drawLine(position_x + xStep, 
 								position_y - lineHeight.toNumber(), 

--- a/Meditate/source/summaryScreen/GraphView.mc
+++ b/Meditate/source/summaryScreen/GraphView.mc
@@ -168,22 +168,22 @@ class GraphView extends ScreenPicker.ScreenPickerView  {
 			var xStep = 1;
 			for (var i = 0; i < me.data.size(); i+=skipSize){
 				var val = me.data[i];
-				if (val!=null && val > 1) {
-					for (var j = 0; j < expandFact; j++){		
-						var lineHeight = (val-yMin) * (graph_height.toFloat() / minMaxDiff.toFloat());
-						dc.drawLine(position_x + xStep, 
-									position_y - lineHeight.toNumber(), 
-									position_x + xStep, 
-									position_y);
-						xStep++;
-					}				
-					// Skip to fit the chart in the screen
-					if (skipSizeFloatPart > 0) {
-						if ((xStep * 1000000) % (skipSizeFloatPart).toNumber() > 1000000) {
-							i++;			
-						}
+				for (var j = 0; j < expandFact; j++){		
+					var lineHeight = 0;
+					if (val!=null) {
+						lineHeight = (val-yMin) * (graph_height.toFloat() / minMaxDiff.toFloat());
 					}
-					
+					dc.drawLine(position_x + xStep, 
+								position_y - lineHeight.toNumber(), 
+								position_x + xStep, 
+								position_y);
+					xStep++;
+				}				
+				// Skip to fit the chart in the screen
+				if (skipSizeFloatPart > 0) {
+					if ((xStep * 1000000) % (skipSizeFloatPart).toNumber() > 1000000) {
+						i++;			
+					}
 				}
 			}
 		}

--- a/Meditate/source/summaryScreen/GraphView.mc
+++ b/Meditate/source/summaryScreen/GraphView.mc
@@ -61,6 +61,11 @@ class GraphView extends ScreenPicker.ScreenPickerView  {
 		graph_height = dc.getHeight() / 3;
 		graph_width =  App.getApp().getProperty("ChartWidth");
 
+		// Validate if we have data history
+		if (me.data == null || me.data.size() <=0) {
+			return;
+		}
+
 		if (me.min instanceof String) {
 			me.min = "--";
 		}
@@ -110,10 +115,6 @@ class GraphView extends ScreenPicker.ScreenPickerView  {
 					TimeFormatter.format(me.elapsedTime), 
 					Graphics.TEXT_JUSTIFY_CENTER|Graphics.TEXT_JUSTIFY_VCENTER);
 		
-		// Validate if we have data history
-		if (me.data == null || me.data.size() <=0) {
-			return;
-		}
 		
 		//DEBUG
 		//me.min = 55;

--- a/Meditate/source/summaryScreen/HrvRmssdGraphView.mc
+++ b/Meditate/source/summaryScreen/HrvRmssdGraphView.mc
@@ -7,8 +7,8 @@ using Toybox.Activity as Activity;
 using Toybox.SensorHistory as SensorHistory;
 using Toybox.ActivityMonitor as ActivityMonitor;
 
-class HeartRateGraphView extends GraphView  {
+class HrvRmssdGraphView extends GraphView  {
 		function initialize(summaryModel) {
-			GraphView.initialize(summaryModel.hrHistory, summaryModel.elapsedTime, Rez.Strings.SummaryHR);
+			GraphView.initialize(summaryModel.hrvRmssdHistory, summaryModel.elapsedTime, Rez.Strings.SummaryHRVRMSSD);
 		}
 }

--- a/Meditate/source/summaryScreen/RespirationRateGraphView.mc
+++ b/Meditate/source/summaryScreen/RespirationRateGraphView.mc
@@ -9,6 +9,6 @@ using Toybox.ActivityMonitor as ActivityMonitor;
 
 class RespirationRateGraphView extends GraphView  {
 		function initialize(summaryModel) {
-			GraphView.initialize(summaryModel.rrHistory, summaryModel.minRr, summaryModel.maxRr, summaryModel.avgRr, summaryModel.elapsedTime, Rez.Strings.SummaryRespiration);
+			GraphView.initialize(summaryModel.rrHistory, summaryModel.elapsedTime, Rez.Strings.SummaryRespiration);
 		}
 }

--- a/Meditate/source/summaryScreen/StressGraphView.mc
+++ b/Meditate/source/summaryScreen/StressGraphView.mc
@@ -9,6 +9,6 @@ using Toybox.ActivityMonitor as ActivityMonitor;
 
 class StressGraphView extends GraphView  {
 		function initialize(summaryModel) {
-			GraphView.initialize(summaryModel.stressHistory, summaryModel.stressMin, summaryModel.stressMax, summaryModel.stressAvg, summaryModel.elapsedTime, Rez.Strings.SummaryStress);
+			GraphView.initialize(summaryModel.stressHistory, summaryModel.elapsedTime, Rez.Strings.SummaryStress);
 		}
 }

--- a/Meditate/source/summaryScreen/StressGraphView.mc
+++ b/Meditate/source/summaryScreen/StressGraphView.mc
@@ -1,0 +1,14 @@
+using Toybox.Math;
+using Toybox.System;
+using Toybox.Application as App;
+using Toybox.WatchUi as Ui;
+using Toybox.Graphics as Gfx;
+using Toybox.Activity as Activity;
+using Toybox.SensorHistory as SensorHistory;
+using Toybox.ActivityMonitor as ActivityMonitor;
+
+class StressGraphView extends GraphView  {
+		function initialize(summaryModel) {
+			GraphView.initialize(summaryModel.stressHistory, summaryModel.stressMin, summaryModel.stressMax, summaryModel.stressAvg, summaryModel.elapsedTime, Rez.Strings.SummaryStress);
+		}
+}

--- a/Meditate/source/summaryScreen/SummaryModel.mc
+++ b/Meditate/source/summaryScreen/SummaryModel.mc
@@ -143,7 +143,7 @@ class SummaryModel {
 			return me.InvalidHeartRate;
 		}
 		else {
-			return stressScore.format("%3.2f");
+			return Math.round(stressScore).format("%3.f");
 		}
 	}
 	
@@ -152,7 +152,7 @@ class SummaryModel {
 			return me.InvalidHeartRate;
 		}
 		else {
-			return hrv.format("%3.2f");
+			return Math.round(hrv).format("%3.f");
 		}
 	}
 		

--- a/Meditate/source/summaryScreen/SummaryModel.mc
+++ b/Meditate/source/summaryScreen/SummaryModel.mc
@@ -39,10 +39,14 @@ class SummaryModel {
 		me.hrvTracking = hrvTracking;
 	}
 
-	function initializeStressHistory (elapsedTimeSeconds) {
+	function initializeStressHistory(elapsedTimeSeconds) {
 
-		stressEnd = null;
-		stressStart = null;
+		me.stressEnd = null;
+		me.stressStart = null;
+		me.stressHistory = [];
+		me.stressMin = null;
+		me.stressMax = null;
+		me.stressAvg = null;
 		var momentStartMediatation = null;
 
 		//DEBUG
@@ -73,6 +77,10 @@ class SummaryModel {
 					return;
 				}
 				me.stressEnd = sample.data;
+				me.stressHistory.add(sample.data);
+				me.stressMin = sample.data;
+				me.stressMax = sample.data;
+
 				//System.println("stressEnd.data:" + sample.data);
 			}
 
@@ -87,6 +95,13 @@ class SummaryModel {
 					// If the stress sample is within the meditation timeframe use it for the stress start metric
 					if (sample.when.greaterThan(momentStartMediatation)) {
 						me.stressStart = sample.data;
+						me.stressHistory.add(sample.data);
+						if(me.stressMax < sample.data){
+							me.stressMax = sample.data;
+						}
+						if(me.stressMin > sample.data){
+							me.stressMin = sample.data;
+						}
 
 						//var sampleDate = Gregorian.info(sample.when, Time.FORMAT_MEDIUM);
 						//System.println("sample.date:" + sampleDate.hour + ":" + sampleDate.min + ":" + sampleDate.sec);
@@ -94,6 +109,10 @@ class SummaryModel {
 					}
 				}
 			}
+			me.stressHistory = stressHistory.reverse();
+			me.stressAvg = Math.round(Math.mean(me.stressHistory));
+			me.stressMin = Math.round(stressMin);
+			me.stressMax = Math.round(stressMax);
 		}
 	}
 
@@ -153,6 +172,10 @@ class SummaryModel {
 	var stress;
 	var stressStart;
 	var stressEnd;
+	var stressMin;
+	var stressMax;
+	var stressAvg;
+	var stressHistory;
 
 	var hrvRmssd;
 	var hrvFirst5Min;

--- a/Meditate/source/summaryScreen/SummaryModel.mc
+++ b/Meditate/source/summaryScreen/SummaryModel.mc
@@ -24,12 +24,12 @@ class SummaryModel {
 			}
 		}
 
-		me.stress = me.initializePercentageValue(activitySummary.stress);
-		
 		initializeStressHistory(me.elapsedTime);
+		me.stress = me.initializePercentageValue(me.stress);
 
 		if (activitySummary.hrvSummary != null) {
 			me.hrvRmssd = me.initializeHeartRateVariability(activitySummary.hrvSummary.rmssd);
+			me.hrvRmssdHistory = activitySummary.hrvSummary.rmssdHistory;
 			me.hrvFirst5Min = me.initializeHeartRateVariability(activitySummary.hrvSummary.first5MinSdrr);
 			me.hrvLast5Min = me.initializeHeartRateVariability(activitySummary.hrvSummary.last5MinSdrr);
 			me.hrvPnn50 = me.initializePercentageValue(activitySummary.hrvSummary.pnn50);
@@ -44,9 +44,6 @@ class SummaryModel {
 		me.stressEnd = null;
 		me.stressStart = null;
 		me.stressHistory = [];
-		me.stressMin = null;
-		me.stressMax = null;
-		me.stressAvg = null;
 		var momentStartMediatation = null;
 
 		//DEBUG
@@ -65,12 +62,6 @@ class SummaryModel {
 				// Calculate the moment of the start of meditation session
 				momentStartMediatation = Time.now().subtract(new Time.Duration(elapsedTimeSeconds));
 
-				//var momentStartStressDate = Gregorian.info(momentStartMediatation, Time.FORMAT_MEDIUM);
-				//System.println("momentStartStress:" + momentStartStressDate.hour + ":" + momentStartStressDate.min + ":" + momentStartStressDate.sec);
-
-				//var sampleDate = Gregorian.info(sample.when, Time.FORMAT_MEDIUM);
-				//System.println("sample date:" + sampleDate.hour + ":" + sampleDate.min + ":" + sampleDate.sec);
-
 				if (momentStartMediatation.greaterThan(sample.when))
 				{
 					//System.println("No stress history data found for the meditation timeframe, exiting.");
@@ -78,8 +69,6 @@ class SummaryModel {
 				}
 				me.stressEnd = sample.data;
 				me.stressHistory.add(sample.data);
-				me.stressMin = sample.data;
-				me.stressMax = sample.data;
 
 				//System.println("stressEnd.data:" + sample.data);
 			}
@@ -96,13 +85,6 @@ class SummaryModel {
 					if (sample.when.greaterThan(momentStartMediatation)) {
 						me.stressStart = sample.data;
 						me.stressHistory.add(sample.data);
-						if(me.stressMax < sample.data){
-							me.stressMax = sample.data;
-						}
-						if(me.stressMin > sample.data){
-							me.stressMin = sample.data;
-						}
-
 						//var sampleDate = Gregorian.info(sample.when, Time.FORMAT_MEDIUM);
 						//System.println("sample.date:" + sampleDate.hour + ":" + sampleDate.min + ":" + sampleDate.sec);
 						//System.println("sample.data:" + sample.data);
@@ -110,9 +92,7 @@ class SummaryModel {
 				}
 			}
 			me.stressHistory = stressHistory.reverse();
-			me.stressAvg = Math.round(Math.mean(me.stressHistory));
-			me.stressMin = Math.round(stressMin);
-			me.stressMax = Math.round(stressMax);
+			me.stress = Math.mean(me.stressHistory);
 		}
 	}
 
@@ -143,7 +123,7 @@ class SummaryModel {
 			return me.InvalidHeartRate;
 		}
 		else {
-			return Math.round(stressScore).format("%3.f");
+			return Math.round(stressScore).format("%3.0f");
 		}
 	}
 	
@@ -152,7 +132,7 @@ class SummaryModel {
 			return me.InvalidHeartRate;
 		}
 		else {
-			return Math.round(hrv).format("%3.f");
+			return Math.round(hrv).format("%3.0f");
 		}
 	}
 		
@@ -172,12 +152,10 @@ class SummaryModel {
 	var stress;
 	var stressStart;
 	var stressEnd;
-	var stressMin;
-	var stressMax;
-	var stressAvg;
 	var stressHistory;
 
 	var hrvRmssd;
+	var hrvRmssdHistory;
 	var hrvFirst5Min;
 	var hrvLast5Min;
 	var hrvPnn50;

--- a/Meditate/source/summaryScreen/SummaryRollupModel.mc
+++ b/Meditate/source/summaryScreen/SummaryRollupModel.mc
@@ -2,14 +2,13 @@ using Toybox.System;
 
 class SummaryRollupModel {
 	function initialize() {		
-		me.mSummaryModels = {};
+		me.mSummaryModels = [];
 	}
 	
 	private var mSummaryModels;
 	
 	public function addSummary(summaryModel) {
-		var newSummaryIndex = me.mSummaryModels.size();
-		mSummaryModels[newSummaryIndex] = summaryModel;
+		me.mSummaryModels.add(summaryModel);
 	}
 	
 	public function getSummary(index) {

--- a/Meditate/source/summaryScreen/SummaryViewDelegate.mc
+++ b/Meditate/source/summaryScreen/SummaryViewDelegate.mc
@@ -49,7 +49,6 @@ class SummaryViewDelegate extends ScreenPicker.ScreenPickerDelegate {
 			}
 		}
 	}
-	private var mPagesCount;
 	// Light results theme
 	var backgroundColor = Gfx.COLOR_WHITE;
 	var foregroundColor = Gfx.COLOR_BLACK;

--- a/Meditate/source/summaryScreen/SummaryViewDelegate.mc
+++ b/Meditate/source/summaryScreen/SummaryViewDelegate.mc
@@ -16,6 +16,7 @@ class SummaryViewDelegate extends ScreenPicker.ScreenPickerDelegate {
 	private static const pageHrvRmssd = "HrvRmssd";
 	private static const pageHrvPnnx = "HrvPnnx";
 	private static const pageHrvSdrr = "HrvSdrr";
+	private static const pageHrvRmssdGraph = "HrvRmssdGraph";
 
 	function initialize(summaryModel, isRespirationRateOn, discardDanglingActivity) {		
 		me.setPageIndexes(summaryModel.hrvTracking, isRespirationRateOn);
@@ -46,6 +47,7 @@ class SummaryViewDelegate extends ScreenPicker.ScreenPickerDelegate {
 			if (hrvTracking == HrvTracking.OnDetailed) {	
 				me.pages.add(me.pageHrvPnnx);
 				me.pages.add(me.pageHrvSdrr);
+				me.pages.add(me.pageHrvRmssdGraph);
 			}
 		}
 	}
@@ -91,6 +93,9 @@ class SummaryViewDelegate extends ScreenPicker.ScreenPickerDelegate {
 			}
 			else if (page.equals(me.pageHrvSdrr)) {
 				details = me.createDetailsPageHrvSdrr();
+			}
+			else if (page.equals(me.pageHrvRmssdGraph)) {
+				return new HrvRmssdGraphView(me.mSummaryModel);
 			}
 			else {
 				return new HeartRateGraphView(me.mSummaryModel);

--- a/Meditate/source/summaryScreen/SummaryViewDelegate.mc
+++ b/Meditate/source/summaryScreen/SummaryViewDelegate.mc
@@ -8,10 +8,18 @@ using HrvAlgorithms.HrvTracking;
 class SummaryViewDelegate extends ScreenPicker.ScreenPickerDelegate {
 	private var mSummaryModel;
 	private var mDiscardDanglingActivity;
+	private var pages;
+	private static const pageHeartRateGraph = "HeartRateGraph";
+	private static const pageRespirationRateGraph = "RespirationRateGraph";
+	private static const pageStressGraph = "StressGraph";
+	private static const pageStress = "Stress";
+	private static const pageHrvRmssd = "HrvRmssd";
+	private static const pageHrvPnnx = "HrvPnnx";
+	private static const pageHrvSdrr = "HrvSdrr";
 
 	function initialize(summaryModel, isRespirationRateOn, discardDanglingActivity) {		
-		me.mPagesCount = SummaryViewDelegate.getPagesCount(summaryModel.hrvTracking, isRespirationRateOn);
-		setPageIndexes(summaryModel.hrvTracking, isRespirationRateOn);
+		me.setPageIndexes(summaryModel.hrvTracking, isRespirationRateOn);
+		me.mPagesCount = me.pages.size();
 		
         ScreenPickerDelegate.initialize(0, me.mPagesCount);
         me.mSummaryModel = summaryModel;
@@ -21,72 +29,27 @@ class SummaryViewDelegate extends ScreenPicker.ScreenPickerDelegate {
 		
 	private var mSummaryLinesYOffset;
 			
-	private static function getPagesCount(hrvTracking, isRespirationRateOn) {		
-		
-		var pagesCount = 6;
-
-		if (hrvTracking == HrvTracking.Off) {
-			pagesCount -= 4;
-		}
-		else if (hrvTracking == HrvTracking.On) {
-			pagesCount -= 2;
-		}
-
-		if (!isRespirationRateOn) {
-			pagesCount -= 1;
-		}
-
-		return pagesCount;
+	private function getPagesCount(hrvTracking, isRespirationRateOn) {		
+		return me.mPagesCount;
 	}
 	
-	private function setPageIndexes(hrvTracking, isRespirationRateOn) {	
-		
-		if (hrvTracking == HrvTracking.Off) {
-			me.mStressPageIndex = InvalidPageIndex;
-			me.mHrvRmssdPageIndex = InvalidPageIndex;
-			me.mHrvSdrrPageIndex = InvalidPageIndex;
-			me.mHrvPnnxPageIndex = InvalidPageIndex;
-
-			if (isRespirationRateOn) {
-				me.mRespirationPageIndex = 1;
-			} else {
-				me.mRespirationPageIndex = InvalidPageIndex;
-			}
-
+	private function setPageIndexes(hrvTracking, isRespirationRateOn) {
+		me.pages = new [0];
+		me.pages.add(me.pageHeartRateGraph);
+		if (isRespirationRateOn) {
+			me.pages.add(me.pageRespirationRateGraph);
 		}
-		else {
-			
-			if (isRespirationRateOn) {
-				me.mRespirationPageIndex = 1;
-				me.mStressPageIndex = 2;
-				me.mHrvRmssdPageIndex = 3;
-			} else {
-				me.mRespirationPageIndex = InvalidPageIndex;
-				me.mStressPageIndex = 1;
-				me.mHrvRmssdPageIndex = 2;
-			}
-				
+		if (hrvTracking == HrvTracking.On or hrvTracking == HrvTracking.OnDetailed){
+			me.pages.add(me.pageStressGraph);
+			me.pages.add(me.pageStress);
+			me.pages.add(me.pageHrvRmssd);
 			if (hrvTracking == HrvTracking.OnDetailed) {	
-				me.mHrvPnnxPageIndex = me.mHrvRmssdPageIndex + 1;	
-				me.mHrvSdrrPageIndex = me.mHrvRmssdPageIndex + 2;
-			}
-			else {
-				me.mHrvPnnxPageIndex = InvalidPageIndex;
-				me.mHrvSdrrPageIndex = InvalidPageIndex;
+				me.pages.add(me.pageHrvPnnx);
+				me.pages.add(me.pageHrvSdrr);
 			}
 		}
 	}
-	
 	private var mPagesCount;
-	
-	private var mHrvRmssdPageIndex;
-	private var mHrvSdrrPageIndex;
-	private var mHrvPnnxPageIndex;
-	private var mStressPageIndex;
-	private var mRespirationPageIndex;
-	
-	private const InvalidPageIndex = -1;
-
 	// Light results theme
 	var backgroundColor = Gfx.COLOR_WHITE;
 	var foregroundColor = Gfx.COLOR_BLACK;
@@ -107,24 +70,32 @@ class SummaryViewDelegate extends ScreenPicker.ScreenPickerDelegate {
 			backgroundColor = Gfx.COLOR_BLACK;
 			foregroundColor = Gfx.COLOR_WHITE;
 		}
-
-		if (me.mSelectedPageIndex == 0) {
-			return new HeartRateGraphView(me.mSummaryModel);
-		} 
-		else if (me.mSelectedPageIndex == me.mRespirationPageIndex) {
-			return new RespirationRateGraphView(me.mSummaryModel);
-		}
-		else if (me.mSelectedPageIndex == me.mStressPageIndex) {
-			details = me.createDetailsPageStress();
-		}
-		else if (me.mSelectedPageIndex == mHrvRmssdPageIndex){
-			details = me.createDetailsPageHrvRmssd();
-		}
-		else if (me.mSelectedPageIndex == mHrvPnnxPageIndex){
-			details = me.createDetailsPageHrvPnnx();
-		} 
-		else if (me.mSelectedPageIndex == mHrvSdrrPageIndex){
-			details = me.createDetailsPageHrvSdrr();
+		if (me.mSelectedPageIndex < me.mPagesCount) {
+			var page = me.pages[me.mSelectedPageIndex];
+			if (page.equals(me.pageHeartRateGraph)) {
+				return new HeartRateGraphView(me.mSummaryModel);
+			}
+			else if (page.equals(me.pageRespirationRateGraph)) {
+				return new RespirationRateGraphView(me.mSummaryModel);
+			}
+			else if (page.equals(me.pageStressGraph)) {
+				return new StressGraphView(me.mSummaryModel);
+			}
+			else if (page.equals(me.pageStress)) {
+				details = me.createDetailsPageStress();
+			}
+			else if (page.equals(me.pageHrvRmssd)) {
+				details = me.createDetailsPageHrvRmssd();
+			}
+			else if (page.equals(me.pageHrvPnnx)) {
+				details = me.createDetailsPageHrvPnnx();
+			}
+			else if (page.equals(me.pageHrvSdrr)) {
+				details = me.createDetailsPageHrvSdrr();
+			}
+			else {
+				return new HeartRateGraphView(me.mSummaryModel);
+			}	
 		} 
 		else {
 			return new HeartRateGraphView(me.mSummaryModel);


### PR DESCRIPTION
added stress & rmssd hrv 30sec graph;
use rmssd hrv 30sec in status page if detail hrv mode on (instead of successive);
less noisy UI - less coginitive load:
* no seconds for timer - meditiation is not messured in seconds
* removed overly accurate numbers - no decimals for hr, hrv, stress
* rmsdd hrv 30 is also far less noisy compared to successive
refactoring:
* reusable rolling and window calc
* better handling of charting (shrink, expand, empty state; null values);
* fixed some type checking errors
* easier sorting of summary screens